### PR TITLE
chore: add Playwright output directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ Thumbs.db
 # Screenshot artifacts (UI Vision walkthroughs, Playwright)
 *.png
 
+# Playwright test output (results, traces, HTML reports)
+test-results/
+playwright-report/
+.playwright-mcp/
+
 # Editor
 .vscode/settings.json
 .idea/


### PR DESCRIPTION
## Summary

Extends `.gitignore` with explicit Playwright output directory entries alongside the existing `*.png` catch-all.

## Change

```
test-results/
playwright-report/
.playwright-mcp/
```

The existing `*.png` entry covers screenshot files, but Playwright also writes traces (`.zip`), HTML reports, and other artifacts into these directories. Adding the directories ensures all test output — not just PNGs — is excluded from version control.
