### PR TITLE
fix: Setup wizard API error handling and disabled tab styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Setup wizard API connection error banner**: RegisterAppStep now shows a clear error banner with a retry button when the backend API is unreachable (connection refused/500 errors), instead of silently failing to load applications.
+- **Setup wizard step tabs visually disabled when no app selected**: Step tabs 2-9 now display with `opacity-50` and `cursor-not-allowed` styling when no application is selected, include `disabled` and `aria-disabled` attributes for accessibility, and show a tooltip explaining "Create or select an application first". Previously tabs were technically disabled but looked clickable.
 - **Discovery race condition — fire-and-forget returns zero counts** (#447): `DiscoveryEngine.startDiscovery()` now `await`s the full discovery run instead of detaching with `.catch()`. The returned `DiscoveryJob` contains real `filesDiscovered`, `filesIndexed`, and `chunksCreated` values. An optional `onProgress` callback streams per-file progress to callers. The `/api/talos/applications/:id/discover` endpoint passes this callback to emit `discovery:progress` Socket.IO events during the scan, giving the UI real-time file-level updates.
 - **Criteria generator 503 on startup**: `CriteriaGenerator` was captured before async `initRag()` completed, leaving it undefined in the router closure. Router now uses a getter `() => criteriaGenerator` so it resolves lazily after initialization.
 - **Jira/Confluence import HTTP errors show actionable detail**: Import endpoint now reads the Jira/Confluence JSON error body (`errorMessages`, `errors`, `message`) and surfaces it in the error response instead of the empty `statusText`.

--- a/ui/components/talos/setup-wizard.test.tsx
+++ b/ui/components/talos/setup-wizard.test.tsx
@@ -209,6 +209,59 @@ describe("#417 – RegisterAppStep", () => {
       expect(screen.getByText("Server error: 500")).toBeInTheDocument();
     });
   });
+
+  it("shows error banner with retry button when getApplications API fails", async () => {
+    mockGetApplications.mockRejectedValueOnce(new Error("Failed to fetch"));
+    renderWizard();
+    await waitFor(() => {
+      expect(screen.getByText(/Cannot connect to the API server/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Retry/i })).toBeInTheDocument();
+  });
+});
+
+// ── Tests for Tab Navigation (#Bug2) ──────────────────────────────────────────
+describe("Tab Navigation", () => {
+  it("step tabs 2-9 are disabled when no app is selected", () => {
+    renderWizard();
+    // Get all step buttons (9 total)
+    const stepButtons = screen.getAllByRole("button").filter((btn) => {
+      const span = btn.querySelector("span.rounded-full");
+      return span && /^[1-9]$/.test(span.textContent || "");
+    });
+    // Steps 2-9 (index 1-8) should be disabled
+    for (let i = 1; i < stepButtons.length; i++) {
+      expect(stepButtons[i]).toBeDisabled();
+      expect(stepButtons[i]).toHaveClass("opacity-50");
+      expect(stepButtons[i]).toHaveClass("cursor-not-allowed");
+    }
+  });
+
+  it("step tabs show tooltip explaining why disabled", () => {
+    renderWizard();
+    const stepButtons = screen.getAllByRole("button").filter((btn) => {
+      const span = btn.querySelector("span.rounded-full");
+      return span && span.textContent === "2";
+    });
+    if (stepButtons.length > 0) {
+      expect(stepButtons[0]).toHaveAttribute("title", "Create or select an application first");
+    }
+  });
+
+  it("step tabs become enabled after selecting an app", async () => {
+    renderWizard();
+    await waitFor(() => expect(screen.getByText("Existing App")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Existing App"));
+    await waitFor(() => expect(screen.getByText("Configure JDBC database connections")).toBeInTheDocument());
+    // Now step tabs should be enabled
+    const stepButtons = screen.getAllByRole("button").filter((btn) => {
+      const span = btn.querySelector("span.rounded-full");
+      return span && span.textContent === "3";
+    });
+    if (stepButtons.length > 0) {
+      expect(stepButtons[0]).not.toBeDisabled();
+    }
+  });
 });
 
 // ── Tests for #414 & #415: UploadDocsStep ─────────────────────────────────────

--- a/ui/components/talos/setup-wizard.tsx
+++ b/ui/components/talos/setup-wizard.tsx
@@ -157,32 +157,39 @@ export function SetupWizard() {
     <div className="space-y-6">
       {/* Progress Bar */}
       <div className="flex items-center gap-2">
-        {STEPS.map((step, i) => (
-          <div key={step.label} className="flex items-center gap-2 flex-1">
-            <button
-              onClick={() => (appId || i === 0 ? setCurrentStep(i) : undefined)}
-              className={cn(
-                "flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors w-full",
-                i === currentStep && "bg-primary text-primary-foreground",
-                i !== currentStep && completedSteps.has(i) && "bg-primary/10 text-primary cursor-pointer",
-                i !== currentStep &&
-                  !completedSteps.has(i) &&
-                  appId &&
-                  "bg-muted text-muted-foreground cursor-pointer hover:bg-muted/80",
-                i !== currentStep && !completedSteps.has(i) && !appId && "bg-muted text-muted-foreground"
-              )}
-            >
-              {completedSteps.has(i) && i !== currentStep ? (
-                <CheckCircle2 className="h-4 w-4 shrink-0" />
-              ) : (
-                <span className="flex h-5 w-5 items-center justify-center rounded-full border text-xs shrink-0">
-                  {i + 1}
-                </span>
-              )}
-              <span className="truncate hidden lg:inline">{step.label}</span>
-            </button>
-          </div>
-        ))}
+        {STEPS.map((step, i) => {
+          // Step 0 is always accessible; other steps require an appId
+          const isDisabled = i !== 0 && !appId;
+          const isActive = i === currentStep;
+          const isComplete = completedSteps.has(i);
+
+          return (
+            <div key={step.label} className="flex items-center gap-2 flex-1">
+              <button
+                onClick={() => !isDisabled && setCurrentStep(i)}
+                disabled={isDisabled}
+                aria-disabled={isDisabled}
+                title={isDisabled ? "Create or select an application first" : step.description}
+                className={cn(
+                  "flex items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors w-full",
+                  isActive && "bg-primary text-primary-foreground",
+                  !isActive && isComplete && "bg-primary/10 text-primary cursor-pointer",
+                  !isActive && !isComplete && !isDisabled && "bg-muted text-muted-foreground cursor-pointer hover:bg-muted/80",
+                  isDisabled && "bg-muted text-muted-foreground opacity-50 cursor-not-allowed"
+                )}
+              >
+                {isComplete && !isActive ? (
+                  <CheckCircle2 className="h-4 w-4 shrink-0" />
+                ) : (
+                  <span className="flex h-5 w-5 items-center justify-center rounded-full border text-xs shrink-0">
+                    {i + 1}
+                  </span>
+                )}
+                <span className="truncate hidden lg:inline">{step.label}</span>
+              </button>
+            </div>
+          );
+        })}
       </div>
 
       {/* Step Content */}
@@ -253,7 +260,12 @@ function RegisterAppStep({
 
   const isValidUrl = (url: string) => url.startsWith("http://") || url.startsWith("https://");
 
-  const { data: apps } = useQuery({ queryKey: ["applications"], queryFn: getApplications });
+  const {
+    data: apps,
+    isError: appsError,
+    error: appsErrorDetails,
+    refetch: refetchApps,
+  } = useQuery({ queryKey: ["applications"], queryFn: getApplications });
 
   const createMutation = useMutation({
     mutationFn: (data: Partial<TalosApplication> & { mtlsEnabled?: boolean; mtlsConfig?: Record<string, string> }) =>
@@ -283,6 +295,22 @@ function RegisterAppStep({
 
   return (
     <div className="space-y-4">
+      {/* API connection error banner */}
+      {appsError && (
+        <div className="flex items-center justify-between gap-2 rounded-md border border-red-500/50 bg-red-500/10 px-4 py-3 text-sm text-red-600">
+          <div className="flex items-center gap-2">
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            <span>
+              {appsErrorDetails instanceof Error && appsErrorDetails.message.includes("fetch")
+                ? "Cannot connect to the API server. Please ensure the backend is running."
+                : getErrorMessage(appsErrorDetails)}
+            </span>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => refetchApps()}>
+            Retry
+          </Button>
+        </div>
+      )}
       {apps && apps.length > 0 && (
         <div className="space-y-2">
           <p className="text-sm text-muted-foreground">Select an existing application or create a new one:</p>

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Fixes two bugs found during UI Vision walkthrough of the setup wizard at `/talos/setup`:

### Bug 1 (Critical): API error 500 handling

**Root Cause:** When the Next.js UI proxy cannot connect to the backend API server (e.g., backend not running, wrong port), the proxy returns a 500 error. The UI had no error handling for this scenario - it silently failed to load applications.

**Fix:** Added an error banner in `RegisterAppStep` that:
- Detects API connection errors (including fetch failures)
- Shows a clear message: "Cannot connect to the API server. Please ensure the backend is running."
- Includes a "Retry" button to re-attempt the connection

### Bug 2 (High): Step tabs don't switch content

**Root Cause:** Step tabs 2-9 are intentionally disabled when no application is selected (you need an app before configuring other steps). However, the tabs weren't visually distinguishable from enabled tabs - they had no `disabled` attribute, no opacity reduction, and no cursor change. Users could click them expecting navigation.

**Fix:** Enhanced tab styling when disabled:
- Added `disabled` and `aria-disabled` attributes for accessibility
- Added `opacity-50` class for visual distinction
- Added `cursor-not-allowed` class to indicate non-clickability
- Added `title` tooltip: "Create or select an application first"

## Changes

- `ui/components/talos/setup-wizard.tsx`: Error handling and tab styling improvements
- `ui/components/talos/setup-wizard.test.tsx`: 4 new tests for error banner and disabled tabs
- `CHANGELOG.md`: Added fix entries under [Unreleased]

## Testing

- ✅ All 83 UI tests pass (including 4 new tests)
- ✅ All 1196 backend tests pass
- ✅ Lint passes (only warnings)
- ✅ TypeScript type check passes
- ✅ Next.js build succeeds